### PR TITLE
feat(dependencies): Add basic dependencies to repo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+ "presets": [ "react", "es2015" ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "yelp-rec-engine",
+  "version": "1.0.0",
+  "description": "[![Stories in Ready](https://badge.waffle.io/ccfcheng/recommendation-app.png?label=ready&title=Ready)](https://waffle.io/ccfcheng/recommendation-app) # recommendation-app",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha --require babel-core/register"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ccfcheng/recommendation-app.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ccfcheng/recommendation-app/issues"
+  },
+  "homepage": "https://github.com/ccfcheng/recommendation-app#readme",
+  "dependencies": {
+    "babel-core": "^6.7.7",
+    "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "express": "^4.13.4",
+    "firebase": "^2.4.2",
+    "material-ui": "^0.15.0-beta.2",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1",
+    "react-tap-event-plugin": "^1.0.0",
+    "yelp": "^1.0.1"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5",
+    "webpack": "^1.13.0"
+  }
+}


### PR DESCRIPTION
Dependencies:
- React and React-DOM
- Express
- Material UI
- Yelp npm module for API wrapper
- Firebase
- Babel packages for ES2015 transpiling

Dev dependencies:
- Mocha/Chai
- Webpack

Closes #1
